### PR TITLE
add quick shift time buttons.

### DIFF
--- a/ui/gui.ui
+++ b/ui/gui.ui
@@ -67,6 +67,114 @@
               <item>
                <widget class="QLineEdit" name="lineEdit_2"/>
               </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_100">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+100</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_200">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+200</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_500">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+500</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_100_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-100</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_200_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-200</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_start_500_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-500</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>
@@ -94,6 +202,114 @@
               </item>
               <item>
                <widget class="QLineEdit" name="lineEdit_3"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_100">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+100</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_200">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+200</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_500">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>+500</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_100_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-100</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_200_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-200</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_end_500_n">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>-500</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>14</width>
+                  <height>14</height>
+                 </size>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -512,8 +728,8 @@
    <slot>click_refreshBTN()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>699</x>
-     <y>190</y>
+     <x>510</x>
+     <y>180</y>
     </hint>
     <hint type="destinationlabel">
      <x>289</x>
@@ -528,8 +744,8 @@
    <slot>click_play_soundBTN()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>647</x>
-     <y>250</y>
+     <x>665</x>
+     <y>239</y>
     </hint>
     <hint type="destinationlabel">
      <x>667</x>
@@ -544,8 +760,8 @@
    <slot>click_backBTN()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>170</x>
-     <y>750</y>
+     <x>197</x>
+     <y>283</y>
     </hint>
     <hint type="destinationlabel">
      <x>181</x>
@@ -560,8 +776,8 @@
    <slot>click_nextBTN()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>561</x>
-     <y>760</y>
+     <x>712</x>
+     <y>283</y>
     </hint>
     <hint type="destinationlabel">
      <x>667</x>
@@ -576,8 +792,8 @@
    <slot>click_checkBTN()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>386</x>
-     <y>755</y>
+     <x>513</x>
+     <y>283</y>
     </hint>
     <hint type="destinationlabel">
      <x>440</x>
@@ -592,8 +808,8 @@
    <slot>click_output_now()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>109</x>
-     <y>645</y>
+     <x>141</x>
+     <y>734</y>
     </hint>
     <hint type="destinationlabel">
      <x>5</x>
@@ -608,12 +824,204 @@
    <slot>click_back_to_main()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>88</x>
-     <y>692</y>
+     <x>122</x>
+     <y>764</y>
     </hint>
     <hint type="destinationlabel">
      <x>5</x>
      <y>720</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_100</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>253</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>239</x>
+     <y>3</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_200</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>313</x>
+     <y>62</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>292</x>
+     <y>-3</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_500</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>411</x>
+     <y>66</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>381</x>
+     <y>0</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_500_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>499</x>
+     <y>59</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>483</x>
+     <y>-7</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_200_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>588</x>
+     <y>66</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>568</x>
+     <y>5</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_start_100_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_start_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>672</x>
+     <y>66</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>648</x>
+     <y>-1</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_100</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>225</x>
+     <y>111</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>746</x>
+     <y>27</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_200</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>347</x>
+     <y>108</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>781</x>
+     <y>39</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_500</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>435</x>
+     <y>100</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>751</x>
+     <y>55</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_500_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>521</x>
+     <y>106</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>772</x>
+     <y>81</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_200_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>607</x>
+     <y>113</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>758</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_end_100_n</sender>
+   <signal>clicked()</signal>
+   <receiver>Mainwindow</receiver>
+   <slot>click_change_end_BTN()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>641</x>
+     <y>112</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>796</x>
+     <y>129</y>
     </hint>
    </hints>
   </connection>
@@ -627,5 +1035,7 @@
   <slot>click_table()</slot>
   <slot>click_output_now()</slot>
   <slot>click_back_to_main()</slot>
+  <slot>click_change_start_BTN()</slot>
+  <slot>click_change_end_BTN()</slot>
  </slots>
 </ui>

--- a/ui/guiclass.py
+++ b/ui/guiclass.py
@@ -18,6 +18,8 @@ from PySide6.QtWidgets import QApplication, QMainWindow, QFrame, QPushButton, QT
 
 from ui import ui_main, ui_gui, ui_inputdata, ui_wait
 
+import traceback
+
 
 class WorkSpaceWindow(QFrame):
     def __init__(self):
@@ -32,6 +34,27 @@ class WorkSpaceWindow(QFrame):
         self.btn_group = QButtonGroup(self.ui.groupBox_2)
         self.btn_group.addButton(self.ui.radioButton, 0)
         self.btn_group.addButton(self.ui.radioButton_2, 1)
+
+    def click_change_start_BTN(self,mtime):
+        try:
+            curmtime = int(self.ui.lineEdit_2.text())
+            # print(curmtime,mtime)
+            curmtime = curmtime + int(mtime)
+        except:
+            curmtime = 0
+            traceback.print_exc()
+            pass
+        self.ui.lineEdit_2.setText(str(curmtime))
+
+    def click_change_end_BTN(self,mtime):
+        try:
+            curmtime = int(self.ui.lineEdit_3.text())
+            curmtime = curmtime + int(mtime)
+        except:
+            curmtime = 0
+            traceback.print_exc()
+            pass
+        self.ui.lineEdit_3.setText(str(curmtime))
 
     def click_refreshBTN(self):
         """ 点击刷新数据列表按钮后触发的槽函数 """

--- a/ui/ui_gui.py
+++ b/ui/ui_gui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'gui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.3.0
+## Created by: Qt User Interface Compiler version 6.3.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -58,6 +58,50 @@ class Ui_Mainwindow(object):
 
         self.horizontalLayout_3.addWidget(self.lineEdit_2)
 
+        self.pushButton_start_100 = QPushButton(self.widget_4)
+        self.pushButton_start_100.setObjectName(u"pushButton_start_100")
+        font1 = QFont()
+        font1.setPointSize(10)
+        self.pushButton_start_100.setFont(font1)
+        self.pushButton_start_100.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_100)
+
+        self.pushButton_start_200 = QPushButton(self.widget_4)
+        self.pushButton_start_200.setObjectName(u"pushButton_start_200")
+        self.pushButton_start_200.setFont(font1)
+        self.pushButton_start_200.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_200)
+
+        self.pushButton_start_500 = QPushButton(self.widget_4)
+        self.pushButton_start_500.setObjectName(u"pushButton_start_500")
+        self.pushButton_start_500.setFont(font1)
+        self.pushButton_start_500.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_500)
+
+        self.pushButton_start_100_n = QPushButton(self.widget_4)
+        self.pushButton_start_100_n.setObjectName(u"pushButton_start_100_n")
+        self.pushButton_start_100_n.setFont(font1)
+        self.pushButton_start_100_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_100_n)
+
+        self.pushButton_start_200_n = QPushButton(self.widget_4)
+        self.pushButton_start_200_n.setObjectName(u"pushButton_start_200_n")
+        self.pushButton_start_200_n.setFont(font1)
+        self.pushButton_start_200_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_200_n)
+
+        self.pushButton_start_500_n = QPushButton(self.widget_4)
+        self.pushButton_start_500_n.setObjectName(u"pushButton_start_500_n")
+        self.pushButton_start_500_n.setFont(font1)
+        self.pushButton_start_500_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_3.addWidget(self.pushButton_start_500_n)
+
 
         self.verticalLayout_5.addWidget(self.widget_4)
 
@@ -76,6 +120,48 @@ class Ui_Mainwindow(object):
 
         self.horizontalLayout_4.addWidget(self.lineEdit_3)
 
+        self.pushButton_end_100 = QPushButton(self.widget_5)
+        self.pushButton_end_100.setObjectName(u"pushButton_end_100")
+        self.pushButton_end_100.setFont(font1)
+        self.pushButton_end_100.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_100)
+
+        self.pushButton_end_200 = QPushButton(self.widget_5)
+        self.pushButton_end_200.setObjectName(u"pushButton_end_200")
+        self.pushButton_end_200.setFont(font1)
+        self.pushButton_end_200.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_200)
+
+        self.pushButton_end_500 = QPushButton(self.widget_5)
+        self.pushButton_end_500.setObjectName(u"pushButton_end_500")
+        self.pushButton_end_500.setFont(font1)
+        self.pushButton_end_500.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_500)
+
+        self.pushButton_end_100_n = QPushButton(self.widget_5)
+        self.pushButton_end_100_n.setObjectName(u"pushButton_end_100_n")
+        self.pushButton_end_100_n.setFont(font1)
+        self.pushButton_end_100_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_100_n)
+
+        self.pushButton_end_200_n = QPushButton(self.widget_5)
+        self.pushButton_end_200_n.setObjectName(u"pushButton_end_200_n")
+        self.pushButton_end_200_n.setFont(font1)
+        self.pushButton_end_200_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_200_n)
+
+        self.pushButton_end_500_n = QPushButton(self.widget_5)
+        self.pushButton_end_500_n.setObjectName(u"pushButton_end_500_n")
+        self.pushButton_end_500_n.setFont(font1)
+        self.pushButton_end_500_n.setIconSize(QSize(14, 14))
+
+        self.horizontalLayout_4.addWidget(self.pushButton_end_500_n)
+
 
         self.verticalLayout_5.addWidget(self.widget_5)
 
@@ -85,8 +171,6 @@ class Ui_Mainwindow(object):
         self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
         self.label_4 = QLabel(self.widget_6)
         self.label_4.setObjectName(u"label_4")
-        font1 = QFont()
-        font1.setPointSize(10)
         self.label_4.setFont(font1)
 
         self.horizontalLayout_5.addWidget(self.label_4)
@@ -313,6 +397,18 @@ class Ui_Mainwindow(object):
         self.pushButton_3.clicked.connect(Mainwindow.click_checkBTN)
         self.pushButton_6.clicked.connect(Mainwindow.click_output_now)
         self.pushButton_7.clicked.connect(Mainwindow.click_back_to_main)
+        self.pushButton_start_100.clicked.connect(lambda: Mainwindow.click_change_start_BTN(100))
+        self.pushButton_start_200.clicked.connect(lambda: Mainwindow.click_change_start_BTN(200))
+        self.pushButton_start_500.clicked.connect(lambda: Mainwindow.click_change_start_BTN(500))
+        self.pushButton_start_500_n.clicked.connect(lambda: Mainwindow.click_change_start_BTN(-500))
+        self.pushButton_start_200_n.clicked.connect(lambda: Mainwindow.click_change_start_BTN(-200))
+        self.pushButton_start_100_n.clicked.connect(lambda: Mainwindow.click_change_start_BTN(-100))
+        self.pushButton_end_100.clicked.connect(lambda: Mainwindow.click_change_end_BTN(100))
+        self.pushButton_end_200.clicked.connect(lambda: Mainwindow.click_change_end_BTN(200))
+        self.pushButton_end_500.clicked.connect(lambda: Mainwindow.click_change_end_BTN(500))
+        self.pushButton_end_500_n.clicked.connect(lambda: Mainwindow.click_change_end_BTN(-500))
+        self.pushButton_end_200_n.clicked.connect(lambda: Mainwindow.click_change_end_BTN(-200))
+        self.pushButton_end_100_n.clicked.connect(lambda: Mainwindow.click_change_end_BTN(-100))
 
         QMetaObject.connectSlotsByName(Mainwindow)
     # setupUi
@@ -321,7 +417,19 @@ class Ui_Mainwindow(object):
         Mainwindow.setWindowTitle(QCoreApplication.translate("Mainwindow", u"\u8bed\u97f3\u6807\u8bb0", None))
         self.groupBox_6.setTitle(QCoreApplication.translate("Mainwindow", u"\u97f3\u9891\u4fe1\u606f", None))
         self.label_2.setText(QCoreApplication.translate("Mainwindow", u"\u5f00\u59cb\u65f6\u95f4", None))
+        self.pushButton_start_100.setText(QCoreApplication.translate("Mainwindow", u"+100", None))
+        self.pushButton_start_200.setText(QCoreApplication.translate("Mainwindow", u"+200", None))
+        self.pushButton_start_500.setText(QCoreApplication.translate("Mainwindow", u"+500", None))
+        self.pushButton_start_100_n.setText(QCoreApplication.translate("Mainwindow", u"-100", None))
+        self.pushButton_start_200_n.setText(QCoreApplication.translate("Mainwindow", u"-200", None))
+        self.pushButton_start_500_n.setText(QCoreApplication.translate("Mainwindow", u"-500", None))
         self.label_3.setText(QCoreApplication.translate("Mainwindow", u"\u7ed3\u675f\u65f6\u95f4", None))
+        self.pushButton_end_100.setText(QCoreApplication.translate("Mainwindow", u"+100", None))
+        self.pushButton_end_200.setText(QCoreApplication.translate("Mainwindow", u"+200", None))
+        self.pushButton_end_500.setText(QCoreApplication.translate("Mainwindow", u"+500", None))
+        self.pushButton_end_100_n.setText(QCoreApplication.translate("Mainwindow", u"-100", None))
+        self.pushButton_end_200_n.setText(QCoreApplication.translate("Mainwindow", u"-200", None))
+        self.pushButton_end_500_n.setText(QCoreApplication.translate("Mainwindow", u"-500", None))
         self.label_4.setText(QCoreApplication.translate("Mainwindow", u"\u5982\u679c\u4f60\u89c9\u5f97\u65f6\u95f4\u5207\u7684\u4e0d\u597d\uff0c\u8bf7\u4fee\u6539\u8fd9\u91cc\u7684\u8d77\u6b62\u65f6\u95f4\n"
 "\uff08\u5355\u4f4d\uff1a\u6beb\u79d2\uff09\u4fee\u6539\u540e\u70b9\u51fb\u64ad\u653e\u97f3\u9891\u53ef\u4ee5\u67e5\u770b\u6548\u679c\n"
 "\uff0c\u622a\u53d6\u5408\u9002\u540e\u70b9\u51fb\u786e\u5b9a\u6807\u6ce8\u624d\u80fd\u4fdd\u5b58\u4fee\u6539", None))


### PR DESCRIPTION
有时候字幕和音频有偏移，每次手工去调数字感觉效率好低，加了一些快捷的时间调整按钮，就可以快速调整时间偏移了。